### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+- Update **yaml-ast-parser** to [0.0.34](https://github.com/mulesoft-labs/yaml-ast-parser/releases/tag/0.0.34).
+  - Some parsing warnings will now correctly display as warnings instead of errors.
+  - Warning is now issued when using tabs in a YAML document.
+  - Corrects false error when a document ends with the [end of document marker](www.yaml.org/spec/1.2/spec.html#id2760395) (`...`).
+- Update **vscode-json-languageservice** to current latest ([1a4e783](https://github.com/Microsoft/vscode-json-languageservice/tree/1a4e783f899825c83fb02fe5bf57daec5ea7993c)).
+
 ## 0.0.5
 - Add support for anchor references.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 0.0.6
 - Update **yaml-ast-parser** to [0.0.34](https://github.com/mulesoft-labs/yaml-ast-parser/releases/tag/0.0.34).
   - Some parsing warnings will now correctly display as warnings instead of errors.
   - Warning is now issued when using tabs in a YAML document.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yaml",
   "displayName": "YAML",
   "description": "YAML for Visual Studio Code",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "adamvoss",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Update **yaml-ast-parser** to [0.0.34](https://github.com/mulesoft-labs/yaml-ast-parser/releases/tag/0.0.34).
  - Some parsing warnings will now correctly display as warnings instead of errors.
  - Warning is now issued when using tabs in a YAML document.
  - Corrects false error when a document ends with the [end of document marker](www.yaml.org/spec/1.2/spec.html#id2760395) (`...`).
- Update **vscode-json-languageservice** to current latest ([1a4e783](https://github.com/Microsoft/vscode-json-languageservice/tree/1a4e783f899825c83fb02fe5bf57daec5ea7993c)).