### PR TITLE
Eliminate use of submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 npm-debug.log
+package-lock.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "server/vscode-yaml-languageservice"]
-	path = server/vscode-yaml-languageservice
-	url = https://github.com/adamvoss/vscode-yaml-languageservice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 0.0.8
 - Update **vscode-json-languageservice** to the current latest version (2.0.14) by updating **vscode-yaml-languageservice**.
 - **vscode-yaml-languageservice** dependency is now managed by `npm`.  This makes development easier.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+- Update **vscode-json-languageservice** to the current latest version (2.0.14) by updating **vscode-yaml-languageservice**.
+- **vscode-yaml-languageservice** dependency is now managed by `npm`.  This makes development easier.
+
 ## 0.0.7
 - Add support for multiple documents in a single file.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ This extension would not have been possible without numerous open source project
 Contributions are welcome!  To install dependencies and begin work, run:
 
 ```sh
-git submodule update --init --recursive
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "main": "./client/out/yamlMain",
   "scripts": {
     "compile": "tsc -p server/ && tsc -p client/",
-    "prepublish": "npm run update-vscode && cd server && ./npminstall.sh",
+    "prepublish": "npm run update-vscode && cd server && npm install",
     "update-vscode": "node ./node_modules/vscode/bin/install",
     "vscode:prepublish": "npm run compile"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yaml",
   "displayName": "YAML",
   "description": "YAML for Visual Studio Code",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "adamvoss",
   "license": "MIT",
   "repository": {

--- a/server/npminstall.sh
+++ b/server/npminstall.sh
@@ -1,5 +1,0 @@
-cd vscode-yaml-languageservice
-./npminstall.sh
-npm run compile
-cd ..
-npm install

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
     "request-light": "^0.2.1",
     "vscode-languageserver": "^3.1.0-alpha.1",
     "vscode-nls": "^2.0.2",
-    "vscode-yaml-languageservice": "file:./vscode-yaml-languageservice"
+    "vscode-yaml-languageservice": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^6.0.51"


### PR DESCRIPTION
Eliminates use of git submodules to provide dependencies.

The **vscode-yaml-languageservice** dependency is now downloaded via `npm`.

This fixes a development environment compatibility issue with npm 5.